### PR TITLE
Prevent MongoDB dependency downgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
           - "*"
         exclude-patterns:
           - "symfony/*"
+          # MongoDB publishes parallel maintained release lines. Keeping it
+          # outside the catch-all group prevents an apparent update from
+          # replacing the newer 2.2.x line with an older 2.1.x release.
+          - "mongodb/mongodb"
         update-types:
           - "patch"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Modification

Exclut `mongodb/mongodb` du lot Composer générique afin qu’il reste suivi séparément.

## Cause

Dependabot interprétait à tort la version `2.1.2` comme une mise à jour de la version `2.2.0` et proposait donc une rétrogradation dans chaque recréation du lot.

## Impact

Les autres correctifs Composer peuvent être proposés et validés sans abaisser la bibliothèque MongoDB.

## Vérification

- syntaxe YAML et diff contrôlés
- labels Dependabot manquants créés dans le dépôt
