### PR TITLE
Upgrade QR code bundle to v7

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,7 @@
 
 # Dépendances locales
 node_modules/
+vendor/
 
 # Cache & logs runtime
 var/log/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Environnement local Docker Compose défini dans `docker-compose.yml`.
 - Nom Compose existant : `cinephoria`.
 - Conteneurs existants : `cinephoria`, `symfony_db_cinephoria`, `mongo_cinephoria`, `phpmyadmin_cinephoria` et `mongo_express_cinephoria`.
-- URLs locales documentées : application `http://localhost:8000`, phpMyAdmin `http://localhost:8081`, Mongo Express `http://localhost:8082` et MailHog `http://localhost:8025`.
+- Le Compose actuel publie l'application sur les ports hôte `80` et `443`, phpMyAdmin sur `127.0.0.1:8081` et Mongo Express sur `127.0.0.1:8082`. Aucun service MailHog ou Mailpit n'y est actuellement défini.
 
 ## Vérifications
 
@@ -34,6 +34,8 @@
 - Toute proposition doit réussir la CI et les vérifications locales pertinentes avant fusion.
 - Les mises à niveau majeures de MariaDB ou MongoDB exigent une sauvegarde vérifiée, un test de migration local et une procédure de retour arrière avant toute utilisation sur un serveur contenant des données.
 - Les mises à niveau majeures de Symfony ou d'un composant applicatif doivent être regroupées et testées fonctionnellement avant fusion.
+- Le bundle `endroid/qr-code-bundle` version 7 utilise `endroid_qr_code.builders.default`; ses routes sont enregistrées automatiquement et aucun fichier dédié sous `config/routes/` n'est nécessaire.
+- L'image de production doit conserver `opcache.save_comments=1`, requis par la compilation de configuration Symfony, et `.dockerignore` doit exclure `vendor/` afin de préserver les dépendances construites dans l'image.
 
 ## Données et contenu
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,9 @@ RUN { \
     echo 'opcache.max_accelerated_files=20000'; \
     echo 'opcache.validate_timestamps=0'; \
     echo 'opcache.revalidate_freq=0'; \
-    echo 'opcache.save_comments=0'; \
+    # Symfony lit les PHPDoc du framework pendant la compilation de sa configuration.
+    # Conserver les commentaires évite un échec propre au conteneur de production.
+    echo 'opcache.save_comments=1'; \
     echo 'opcache.fast_shutdown=1'; \
     echo 'opcache.enable_file_override=1'; \
     echo 'opcache.max_wasted_percentage=10'; \

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "doctrine/mongodb-odm-bundle": "^5.3",
     "doctrine/orm": "^3.3",
     "endroid/qr-code": "^6.0",
-    "endroid/qr-code-bundle": "^6.0",
+    "endroid/qr-code-bundle": "^7.0",
     "lexik/jwt-authentication-bundle": "^3.1.1",
     "mongodb/mongodb": "^2.0",
     "symfony/console": "8.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84edb935ec6b73bb6576ddf259b76dd4",
+    "content-hash": "9a77aaa4dd9292df65a6e8beedb12fcf",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1501,66 +1501,6 @@
             "time": "2025-03-06T22:45:56+00:00"
         },
         {
-            "name": "endroid/installer",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/endroid/installer.git",
-                "reference": "20ecb9cf11c9e6b98aa045e9099e7290ebd8aa6c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/endroid/installer/zipball/20ecb9cf11c9e6b98aa045e9099e7290ebd8aa6c",
-                "reference": "20ecb9cf11c9e6b98aa045e9099e7290ebd8aa6c",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^2.0",
-                "php": "^8.4"
-            },
-            "require-dev": {
-                "composer/composer": "^2.0",
-                "endroid/quality": "dev-main"
-            },
-            "suggest": {
-                "roave/security-advisories": "Avoids installation of package versions with vulnerabilities"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Endroid\\Installer\\Installer",
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Endroid\\Installer\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jeroen van den Enden",
-                    "email": "info@endroid.nl"
-                }
-            ],
-            "description": "Composer plugin for installing configuration files",
-            "support": {
-                "issues": "https://github.com/endroid/installer/issues",
-                "source": "https://github.com/endroid/installer/tree/1.5.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/endroid",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-11-23T20:15:07+00:00"
-        },
-        {
             "name": "endroid/qr-code",
             "version": "6.1.3",
             "source": {
@@ -1634,25 +1574,23 @@
         },
         {
             "name": "endroid/qr-code-bundle",
-            "version": "6.1.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/endroid/qr-code-bundle.git",
-                "reference": "b6557949d735feee23d0cfb34969e005402ff7df"
+                "reference": "9d9701bae43ab45c7b082f492c0018c6324310c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/endroid/qr-code-bundle/zipball/b6557949d735feee23d0cfb34969e005402ff7df",
-                "reference": "b6557949d735feee23d0cfb34969e005402ff7df",
+                "url": "https://api.github.com/repos/endroid/qr-code-bundle/zipball/9d9701bae43ab45c7b082f492c0018c6324310c7",
+                "reference": "9d9701bae43ab45c7b082f492c0018c6324310c7",
                 "shasum": ""
             },
             "require": {
-                "endroid/installer": "^1.5",
                 "endroid/qr-code": "^6.1.0",
                 "php": "^8.4",
                 "symfony/framework-bundle": "^6.4||^7.4||^8.0",
-                "symfony/twig-bundle": "^6.4||^7.4||^8.0",
-                "symfony/yaml": "^6.4||^7.4||^8.0"
+                "symfony/twig-bundle": "^6.4||^7.4||^8.0"
             },
             "require-dev": {
                 "endroid/quality": "dev-main"
@@ -1663,7 +1601,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.x-dev"
+                    "dev-main": "7.x-dev"
                 }
             },
             "autoload": {
@@ -1693,7 +1631,7 @@
             ],
             "support": {
                 "issues": "https://github.com/endroid/qr-code-bundle/issues",
-                "source": "https://github.com/endroid/qr-code-bundle/tree/6.1.0"
+                "source": "https://github.com/endroid/qr-code-bundle/tree/7.0.1"
             },
             "funding": [
                 {
@@ -1701,7 +1639,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-01T22:03:15+00:00"
+            "time": "2026-05-20T21:21:57+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",

--- a/config/packages/endroid_qr_code.yaml
+++ b/config/packages/endroid_qr_code.yaml
@@ -1,9 +1,11 @@
 endroid_qr_code:
-    default:
-        writer: Endroid\QrCode\Writer\PngWriter
-        size: 300
-        margin: 10
-        encoding: 'UTF-8'
-        error_correction_level: 'low'
-        round_block_size_mode: 'margin'
-        validate_result: false
+    # Depuis la version 7 du bundle, chaque configuration nommée se place sous "builders".
+    builders:
+        default:
+            writer: Endroid\QrCode\Writer\PngWriter
+            size: 300
+            margin: 10
+            encoding: 'UTF-8'
+            error_correction_level: 'low'
+            round_block_size_mode: 'margin'
+            validate_result: false

--- a/config/routes/endroid_qr_code.yaml
+++ b/config/routes/endroid_qr_code.yaml
@@ -1,3 +1,0 @@
-endroid_qr_code:
-    resource: "@EndroidQrCodeBundle/Resources/config/routes.yaml"
-    prefix: /qr-code


### PR DESCRIPTION
## Résumé

- Met à jour `endroid/qr-code-bundle` vers la version 7.
- Migre la configuration vers `builders` et retire l’ancienne route devenue obsolète.
- Conserve les PHPDoc requis par Symfony dans OPcache.
- Empêche le dossier `vendor` local d’écraser les dépendances construites dans l’image.

## Vérifications

- Validation Composer stricte.
- Construction Docker complète.
- Route `qr_code_generate` chargée.
- Génération réelle d’un PNG via le kernel : HTTP 200, `image/png`.
